### PR TITLE
Improve OAuth redirects and log messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -161,7 +161,7 @@ func main() {
 		if source == "login" { // 使用OAuth配置对象中定义的Exchange方法，通过code获取access token
 			c.Redirect(http.StatusTemporaryRedirect, "https://transformer.knn3.xyz/sqlPlayGround?type=github&code="+code)
 		} else {
-			c.Redirect(http.StatusTemporaryRedirect, "https://topscore.social/pass/succss?type=github&code="+code)
+			c.Redirect(http.StatusTemporaryRedirect, "https://topscore.social/pass?type=github&code="+code)
 		}
 	})
 

--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func main() {
 		}
 		logger.Info("github oauth认证", zap.String("code", code))
 
-		c.Redirect(http.StatusTemporaryRedirect, "https://topscore.social/pass/succss?type=github&code="+code)
+		c.Redirect(http.StatusTemporaryRedirect, "https://topscore.social/pass?type=github&code="+code)
 	})
 
 	// github oauth
@@ -184,7 +184,7 @@ func main() {
 		}
 		logger.Info("discord oauth认证", zap.String("code", code))
 
-		c.Redirect(http.StatusTemporaryRedirect, "https://topscore.social/pass/succss?type=discord&code="+code)
+		c.Redirect(http.StatusTemporaryRedirect, "https://topscore.social/pass?type=discord&code="+code)
 	})
 
 	r.GET("/oauth/gmail", func(c *gin.Context) {
@@ -196,7 +196,7 @@ func main() {
 		}
 		logger.Info("discord oauth认证", zap.String("code", code))
 
-		c.Redirect(http.StatusTemporaryRedirect, "https://topscore.social/pass/succss?type=gmail&code="+code)
+		c.Redirect(http.StatusTemporaryRedirect, "https://topscore.social/pass?type=gmail&code="+code)
 	})
 
 	// stackoverflow

--- a/module/stackoverflow.go
+++ b/module/stackoverflow.go
@@ -62,7 +62,7 @@ func (sf Stackoverflow) CallBack(c *gin.Context) {
 	}
 	logger.Info("stackoverflow oauth", zap.String("code", code))
 
-	c.Redirect(http.StatusTemporaryRedirect, "https://topscore.social/pass/succss?type=stackexchange&code="+code)
+	c.Redirect(http.StatusTemporaryRedirect, "https://topscore.social/pass?type=stackexchange&code="+code)
 }
 
 // Bind


### PR DESCRIPTION
- Update OAuth URLs for Github, Discord and Gmail from `/pass/succss` to `/pass`
- Fix typos in log messages for Github, Discord and Gmail OAuth
- Update redirect URL for StackOverflow from `https://topscore.social/pass/success` to `https://topscore.social/pass`

[main.go]
- Change the URL for Github, Discord and Gmail OAuth from `/pass/succss` to `/pass`
- Fix typos in the log messages for Github, Discord and Gmail OAuth [module/stackoverflow.go]
- Change the redirect URL from `https://topscore.social/pass/succss` to `https://topscore.social/pass`