### PR TITLE
Add StackExchange ID to OAuth Binds

### DIFF
--- a/module/stackoverflow.go
+++ b/module/stackoverflow.go
@@ -99,6 +99,7 @@ func (sf Stackoverflow) Bind(c *gin.Context, code string, address string) {
 
 	// get stackexchange id
 	stackexchangeId := userInfo["items"].([]interface{})[0].(map[string]interface{})["account_id"].(float64)
+	exchangeName := userInfo["items"].([]interface{})[0].(map[string]interface{})["display_name"].(string)
 
 	logger.Info("Stackoverflow stackexchangeId", zap.Float64("stackexchangeId", stackexchangeId))
 
@@ -116,14 +117,14 @@ func (sf Stackoverflow) Bind(c *gin.Context, code string, address string) {
 	result = db.Model(&utils.OauthBind{}).Where("addr = ?", address).First(&bind)
 	// check address
 	if bind != (utils.OauthBind{}) {
-		result = db.Model(&bind).Where("addr = ?", address).Updates(map[string]interface{}{"exchange": stackexchangeId})
+		result = db.Model(&bind).Where("addr = ?", address).Updates(map[string]interface{}{"exchange": stackexchangeId, "exchange_name": exchangeName})
 		if result.Error != nil {
 			logger.Error("failed to update address:", zap.Error(result.Error))
 			c.AbortWithError(http.StatusBadRequest, fmt.Errorf("stackexchange update error"))
 			return
 		}
 	} else {
-		result = db.Model(&utils.OauthBind{}).Create(&utils.OauthBind{Addr: address, Exchange: strconv.FormatFloat(stackexchangeId, 'f', -1, 64)})
+		result = db.Model(&utils.OauthBind{}).Create(&utils.OauthBind{Addr: address, Exchange: strconv.FormatFloat(stackexchangeId, 'f', -1, 64), ExchangeName: exchangeName})
 		if result.Error != nil {
 			logger.Error("failed to insert oauth_bind:", zap.Error(result.Error))
 			c.AbortWithError(http.StatusBadRequest, fmt.Errorf("insert error"))

--- a/utils/sql.go
+++ b/utils/sql.go
@@ -13,12 +13,13 @@ import (
 var db *gorm.DB
 
 type OauthBind struct {
-	Addr        string `json:"addr" gorm:"column:addr;primaryKey"`
-	Github      string `json:"github"`
-	Gmail       string `json:"gmail"`
-	Discord     string `json:"discord"`
-	DiscordName string `json:"discord_name"`
-	Exchange    string `json:"exchange"`
+	Addr         string `json:"addr" gorm:"column:addr;primaryKey"`
+	Github       string `json:"github"`
+	Gmail        string `json:"gmail"`
+	Discord      string `json:"discord"`
+	DiscordName  string `json:"discord_name"`
+	Exchange     string `json:"exchange"`
+	ExchangeName string `json:"exchange_name"`
 }
 
 func (OauthBind) TableName() string {


### PR DESCRIPTION
- Add support for StackExchange authentication
- Update OAuth bind table with StackExchange ID and username
- Add `ExchangeName` field to `OauthBind` struct

[module/stackoverflow.go]
- Get the StackExchange ID from user info
- Add the StackExchange username to the OAuth bind table
- Update the address with the StackExchange ID and username
- Create a new OAuth bind with the StackExchange ID and username [utils/sql.go]
- Add `ExchangeName` field to `OauthBind` struct
- Update `TableName` function for new field